### PR TITLE
Add Docker Registry v2 client protocol

### DIFF
--- a/100-config.yaml
+++ b/100-config.yaml
@@ -6,11 +6,12 @@ metadata:
 data:
   KEYCLOAK_USER: admin@keycloak
   KEYCLOAK_MGMT_USER: mgmt@keycloak
-  DB_VENDOR: POSTGRES
-  POSTGRES_HOST: postgres.postgres.svc.cluster.local
-  POSTGRES_PORT: "5432"
-  POSTGRES_DATABASE: keycloak
-  POSTGRES_USER: keycloak
-  PROXY_ADDRESS_FORWARDING: "true"
+  JAVA_OPTS_APPEND: '-Dkeycloak.profile.feature.docker=enabled'
+  PROXY_ADDRESS_FORWARDING: 'true'
   KEYCLOAK_LOGLEVEL: INFO
   ROOT_LOGLEVEL: INFO
+  DB_VENDOR: POSTGRES
+  POSTGRES_HOST: postgres.postgres.svc.cluster.local
+  POSTGRES_PORT: '5432'
+  POSTGRES_DATABASE: keycloak
+  POSTGRES_USER: keycloak

--- a/600-deployment.yaml
+++ b/600-deployment.yaml
@@ -41,6 +41,11 @@ spec:
                 configMapKeyRef:
                   name: keycloak
                   key: KEYCLOAK_MGMT_USER
+            - name: JAVA_OPTS_APPEND
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: JAVA_OPTS_APPEND
             - name: DB_VENDOR
               valueFrom:
                 configMapKeyRef:
@@ -101,4 +106,3 @@ spec:
       #   - name: keycloak-data
       #     persistentVolumeClaim:
       #       claimName: keycloak-pvc
-    


### PR DESCRIPTION
Docker Registry V2 Authentication is an OIDC-Like protocol used to authenticate users against a Docker registry.
The Keycloak implementation of this protocol allows for a Keycloak authentication server to be used by a
Docker client to authenticate against a registry. To be able to select this as a protocol when configuring
clients the feature needs to be enabled as it is not available by default. This can be done using the
JAVA_OPTS_APPEND environment and the feature flag for this.